### PR TITLE
Updated submodule link, to the last freedesktop gitlab repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = git://anongit.freedesktop.org/gstreamer/common
+	url = https://gitlab.freedesktop.org/gstreamer/common.git/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = https://gitlab.freedesktop.org/gstreamer/common.git/
+	url = https://anongit.freedesktop.org/git/gstreamer/common.git


### PR DESCRIPTION
Hi,
I think git://anongit.freedesktop.org/gstreamer/common doesn't exist any more. Updated to last link. Also it is an archived project, it would be wise to not use it in the future.