### PR TITLE
fixing dead link for common submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = git://anongit.freedesktop.org/gstreamer/common
+	url = https://github.com/GStreamer/common


### PR DESCRIPTION
The git://anongit.freedesktop.org/gstreamer/common is no longer available. 
This PR will change the link to https://github.com/GStreamer/common